### PR TITLE
Rollback some starship changes

### DIFF
--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -10,8 +10,5 @@ show_always = true
 [battery]
 charging_symbol = "⚡️"
 
-[directory]
-truncate_to_repo = false
-
 [golang]
 symbol = " "

--- a/starship/starship.toml
+++ b/starship/starship.toml
@@ -13,8 +13,5 @@ charging_symbol = "⚡️"
 [directory]
 truncate_to_repo = false
 
-[hostname]
-ssh_only = false
-
 [golang]
 symbol = " "


### PR DESCRIPTION
- show the host only if ssh is on bc I now see that this is prettier
- truncate the path to the repo, bc this is prettier and keeps the prompt shorter

Those changes were just added in #8 but I realized, that the default values are better
